### PR TITLE
Specify pnpm version in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup pnpm 🔧
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.0.0
 
       - name: Determine pnpm store path 📦
         id: pnpm-store


### PR DESCRIPTION
## Summary
- pin the pnpm setup action to version 9.0.0 to match the repository's package manager configuration

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68d83902350c832f811f79343150ddb8