### PR TITLE
Fix TypeScript definitions and resolve context regressions

### DIFF
--- a/src/components/AdvancedDownloads.tsx
+++ b/src/components/AdvancedDownloads.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import type { JSX } from 'react';
 import styles from './AdvancedDownloads.module.css';
 
 interface ReleaseItem {
@@ -58,10 +59,19 @@ export default function AdvancedDownloads(): JSX.Element {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   useEffect(() => {
+    const safeFetch = async (url: string): Promise<Response | null> => {
+      try {
+        const response = await fetch(url);
+        return response.ok ? response : null;
+      } catch {
+        return null;
+      }
+    };
+
     const fetchReleases = async () => {
       try {
         setLoading(true);
-        
+
         // Try multiple CORS proxies as fallback
         const proxies = [
           'https://cors-anywhere.herokuapp.com/',
@@ -70,22 +80,23 @@ export default function AdvancedDownloads(): JSX.Element {
           'https://proxy.cors.sh/'
         ];
         
-        let stableData, devData;
-        let lastError;
-        
+        let stableData: ReleaseData | null = null;
+        let devData: ReleaseData | null = null;
+        let lastError: unknown;
+
         for (const proxyUrl of proxies) {
           try {
             // Try to fetch all available JSON files
             const [stableResponse, stableResponse2, devResponse] = await Promise.all([
-              fetch(proxyUrl + 'https://github.com/OpenHD/OpenHD-ImageWriter/releases/download/Json/OpenHD-download-index.json').catch(() => ({ ok: false })),
-              fetch(proxyUrl + 'https://github.com/OpenHD/OpenHD-ImageWriter/releases/download/Json/OpenHD-download-index.json_1.json').catch(() => ({ ok: false })),
-              fetch(proxyUrl + 'https://github.com/OpenHD/OpenHD-ImageWriter/releases/download/Json/OpenHD-development-releases.json').catch(() => ({ ok: false }))
+              safeFetch(proxyUrl + 'https://github.com/OpenHD/OpenHD-ImageWriter/releases/download/Json/OpenHD-download-index.json'),
+              safeFetch(proxyUrl + 'https://github.com/OpenHD/OpenHD-ImageWriter/releases/download/Json/OpenHD-download-index.json_1.json'),
+              safeFetch(proxyUrl + 'https://github.com/OpenHD/OpenHD-ImageWriter/releases/download/Json/OpenHD-development-releases.json')
             ]);
 
             // Use whichever stable response is successful
-            const workingStableResponse = stableResponse.ok ? stableResponse : (stableResponse2.ok ? stableResponse2 : null);
-            
-            if (workingStableResponse && devResponse.ok) {
+            const workingStableResponse = stableResponse ?? stableResponse2;
+
+            if (workingStableResponse && devResponse) {
               stableData = await workingStableResponse.json();
               devData = await devResponse.json();
               break; // Success, exit loop

--- a/src/components/AppDownloadBanner.tsx
+++ b/src/components/AppDownloadBanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { JSX } from 'react';
 import ModernQRCode from './ModernQRCode';
 import styles from './AppDownloadBanner.module.css';
 

--- a/src/components/ModernQRCode.tsx
+++ b/src/components/ModernQRCode.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import type { JSX } from 'react';
 import QRCodeStyling from 'qr-code-styling';
 import styles from './ModernQRCode.module.css';
 

--- a/src/components/Navbar/CommunityDropdown.tsx
+++ b/src/components/Navbar/CommunityDropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import type { JSX } from 'react';
 import { useWindowSize } from '@docusaurus/theme-common';
 import styles from './CommunityDropdown.module.css';
 

--- a/src/components/ProtectedEmail.tsx
+++ b/src/components/ProtectedEmail.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import type { JSX } from 'react';
 
 interface ProtectedEmailProps {
   user: string;

--- a/src/components/SnakeGame/index.tsx
+++ b/src/components/SnakeGame/index.tsx
@@ -30,7 +30,7 @@ export default function SnakeGame(): React.JSX.Element {
   const [score, setScore] = useState(0);
   const [highScore, setHighScore] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
-  const gameLoopRef = useRef<NodeJS.Timeout>();
+  const gameLoopRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Load high score from localStorage
   useEffect(() => {

--- a/src/contexts/GitHubStarsContext.tsx
+++ b/src/contexts/GitHubStarsContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import type { JSX } from 'react';
 
 interface GitHubStarsData {
   stars: number | null;
@@ -7,108 +8,78 @@ interface GitHubStarsData {
   lastFetched: number | null;
 }
 
-interface FundingData {
-  amount: number | null;
-  isLoading: boolean;
-  error: string | null;
-  lastFetched: number | null;
-}
-
-interface AppContextType {
-  githubData: GitHubStarsData;
-  fundingData: FundingData;
+interface GitHubStarsContextValue {
+  data: GitHubStarsData;
   fetchStars: (repo: string) => Promise<void>;
-  fetchFunding: () => Promise<void>;
 }
 
-const AppContext = createContext<AppContextType | null>(null);
+const STALE_THRESHOLD_MS = 10 * 60 * 1000;
 
-// Global cache outside of React to persist across re-renders
-let globalStarsCache: { [repo: string]: GitHubStarsData } = {};
-let globalFundingCache: FundingData = {
-  amount: null,
-  isLoading: true,
-  error: null,
-  lastFetched: null
-};
+const GitHubStarsContext = createContext<GitHubStarsContextValue | undefined>(undefined);
 
-export function AppProvider({ children }: { children: ReactNode }) {
-  const [githubData, setGithubData] = useState<GitHubStarsData>({
+// Cache that lives outside of React to survive component unmounts
+const globalStarsCache: Record<string, GitHubStarsData> = {};
+
+export function GitHubStarsProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [data, setData] = useState<GitHubStarsData>({
     stars: null,
     isLoading: true,
     error: null,
-    lastFetched: null
+    lastFetched: null,
   });
 
-  const [fundingData, setFundingData] = useState<FundingData>({
-    amount: null,
-    isLoading: true,
-    error: null,
-    lastFetched: null
-  });
+  const fetchStars = useCallback(async (repo: string) => {
+    const now = Date.now();
+    const cached = globalStarsCache[repo];
 
-  const fetchStars = async (repo: string) => {
-    // Check global cache first
-    if (globalStarsCache[repo] && globalStarsCache[repo].stars !== null) {
-      setData(globalStarsCache[repo]);
-      
-      // Only refetch if data is older than 10 minutes
-      const isStale = !globalStarsCache[repo].lastFetched || 
-                     Date.now() - globalStarsCache[repo].lastFetched! > 10 * 60 * 1000;
-      
-      if (!isStale) {
+    if (cached && cached.stars !== null) {
+      setData(cached);
+      if (cached.lastFetched && now - cached.lastFetched < STALE_THRESHOLD_MS) {
         return;
       }
     }
 
-    // Check localStorage cache
     const CACHE_KEY = `github_stars_${repo}`;
-    const cached = localStorage.getItem(CACHE_KEY);
-    
-    if (cached) {
-      try {
-        const { stars, timestamp } = JSON.parse(cached);
-        const cacheData = {
-          stars,
-          isLoading: false,
-          error: null,
-          lastFetched: timestamp
-        };
-        
-        // Update both global cache and state
-        globalStarsCache[repo] = cacheData;
-        setData(cacheData);
-        
-        // If cache is fresh, don't make API call
-        if (Date.now() - timestamp < 10 * 60 * 1000) {
-          return;
+    if (typeof window !== 'undefined') {
+      const localCache = window.localStorage.getItem(CACHE_KEY);
+      if (localCache) {
+        try {
+          const parsed = JSON.parse(localCache) as { stars: number; timestamp: number };
+          const cacheData: GitHubStarsData = {
+            stars: parsed.stars,
+            isLoading: false,
+            error: null,
+            lastFetched: parsed.timestamp,
+          };
+          globalStarsCache[repo] = cacheData;
+          setData(cacheData);
+          if (now - parsed.timestamp < STALE_THRESHOLD_MS) {
+            return;
+          }
+        } catch {
+          window.localStorage.removeItem(CACHE_KEY);
         }
-      } catch (e) {
-        localStorage.removeItem(CACHE_KEY);
       }
     }
 
-    // Make API call only if needed
     try {
       const response = await fetch(`https://api.github.com/repos/${repo}`, {
         headers: {
-          'Accept': 'application/vnd.github.v3+json',
-          'User-Agent': 'OpenHD-Website'
-        }
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'OpenHD-Website',
+        },
       });
-      
+
       if (!response.ok) {
         if (response.status === 403 || response.status === 429) {
-          // Rate limited - keep existing data if we have it
-          if (globalStarsCache[repo]?.stars !== null) {
+          if (cached?.stars !== null) {
             return;
           }
-          // Otherwise hide stars
-          const errorData = {
+          const errorData: GitHubStarsData = {
             stars: null,
             isLoading: false,
             error: 'rate_limited',
-            lastFetched: Date.now()
+            lastFetched: now,
           };
           globalStarsCache[repo] = errorData;
           setData(errorData);
@@ -118,53 +89,54 @@ export function AppProvider({ children }: { children: ReactNode }) {
       }
 
       const apiData = await response.json();
-      const starCount = apiData.stargazers_count;
-      
-      // Cache the result
+      const starCount = apiData.stargazers_count as number | undefined;
       const timestamp = Date.now();
-      localStorage.setItem(CACHE_KEY, JSON.stringify({
-        stars: starCount,
-        timestamp
-      }));
-      
-      const newData = {
-        stars: starCount,
+
+      if (typeof window !== 'undefined' && typeof starCount === 'number') {
+        window.localStorage.setItem(CACHE_KEY, JSON.stringify({
+          stars: starCount,
+          timestamp,
+        }));
+      }
+
+      const newData: GitHubStarsData = {
+        stars: typeof starCount === 'number' ? starCount : null,
         isLoading: false,
         error: null,
-        lastFetched: timestamp
+        lastFetched: timestamp,
       };
-      
+
       globalStarsCache[repo] = newData;
       setData(newData);
-      
-    } catch (err) {
-      console.warn('Failed to fetch GitHub stars:', err);
-      
-      // Keep existing cached data if available
-      if (globalStarsCache[repo]?.stars !== null) {
+    } catch (error) {
+      console.warn('Failed to fetch GitHub stars:', error);
+      if (cached?.stars !== null) {
         return;
       }
-      
-      // Final fallback
-      const errorData = {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      const errorData: GitHubStarsData = {
         stars: null,
         isLoading: false,
-        error: err.message,
-        lastFetched: Date.now()
+        error: message,
+        lastFetched: Date.now(),
       };
       globalStarsCache[repo] = errorData;
       setData(errorData);
     }
-  };
+  }, []);
 
-  return (
-    <GitHubStarsContext.Provider value={{ data, fetchStars }}>
-      {children}
-    </GitHubStarsContext.Provider>
+  const value = useMemo(
+    () => ({
+      data,
+      fetchStars,
+    }),
+    [data, fetchStars],
   );
+
+  return <GitHubStarsContext.Provider value={value}>{children}</GitHubStarsContext.Provider>;
 }
 
-export function useGitHubStars() {
+export function useGitHubStars(): GitHubStarsContextValue {
   const context = useContext(GitHubStarsContext);
   if (!context) {
     throw new Error('useGitHubStars must be used within a GitHubStarsProvider');

--- a/src/pages/hardware-configurator-debug.tsx
+++ b/src/pages/hardware-configurator-debug.tsx
@@ -3,21 +3,25 @@ import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import styles from './hardware-configurator-debug.module.css';
 import { hardwareConfiguratorService } from '../services/HardwareConfiguratorService';
-import { 
+import {
   HardwareConfiguratorData,
   SBCComponent,
   CameraComponent,
   WiFiComponent,
   ValidationRule,
+  StructuredRule,
   UseCase,
   ConfiguratorStats,
   ComponentStatus
 } from '../types/hardware-configurator';
 import CompatibilityMatrix from '../components/debug/CompatibilityMatrix';
 
+type CategoryKey = keyof HardwareConfiguratorData['component_categories'];
+type ComponentData = HardwareConfiguratorData['component_categories'][CategoryKey]['components'][number];
+
 export default function HardwareConfiguratorDebug() {
   const [activeTab, setActiveTab] = useState<'overview' | 'components' | 'rules' | 'usecases' | 'compatibility'>('overview');
-  const [selectedCategory, setSelectedCategory] = useState<string>('sbcs');
+  const [selectedCategory, setSelectedCategory] = useState<CategoryKey>('sbcs');
   const [data, setData] = useState<HardwareConfiguratorData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -445,7 +449,7 @@ const StatusBadge: React.FC<{ status?: string }> = ({ status }) => {
             {activeTab === 'components' && (
               <div className={styles.components}>
                 <div className={styles.categorySelector}>
-                  {Object.keys(data.component_categories).map(category => (
+                  {(Object.keys(data.component_categories) as CategoryKey[]).map(category => (
                     <button
                       key={category}
                       className={`${styles.categoryButton} ${selectedCategory === category ? styles.active : ''}`}

--- a/src/services/HardwareConfiguratorService.ts
+++ b/src/services/HardwareConfiguratorService.ts
@@ -302,7 +302,7 @@ class RuleEvaluator {
   }
 
   private evaluateStructuredRule(rule: ValidationRule, context: EvaluationContext): boolean {
-    const { type, parameters } = rule;
+    const { type, parameters = {} } = rule;
 
     // Map old rule types to new ones for backward compatibility
     let mappedType = type;

--- a/src/types/hardware-configurator.ts
+++ b/src/types/hardware-configurator.ts
@@ -85,17 +85,24 @@ export interface ValidationRule {
   type: RuleType;
   severity: SeverityLevel;
   message: string;
-  parameters: RuleParameters;
+  parameters?: RuleParameters;
+  condition?: string;
+  deprecated?: boolean;
+  structured_equivalent?: string;
+  auto_generated?: boolean;
 }
 
-export type RuleType = 
+export type RuleType =
   | 'interface_compatibility'
-  | 'manufacturer_compatibility' 
+  | 'manufacturer_compatibility'
   | 'status_check'
   | 'feature_check'
   | 'count_check'
   | 'chipset_whitelist'
-  | 'role_compatibility';
+  | 'role_compatibility'
+  | 'interface_mismatch'
+  | 'role_incompatible'
+  | 'manufacturer_mismatch';
 
 export interface RuleParameters {
   // Common parameters
@@ -109,6 +116,7 @@ export interface RuleParameters {
   };
   
   // Interface rules
+  required_interface?: string;
   required_interfaces?: string[];
   
   // Manufacturer rules (completely flexible)
@@ -147,6 +155,9 @@ export interface RuleParameters {
   
   // Chipset rules
   chipset_whitelist?: string[];
+  component_type?: string;
+  target_type?: string;
+  use_global_whitelist?: boolean;
   
   // Role rules
   role_requirements?: {
@@ -207,6 +218,12 @@ export interface HardwareConfiguratorData {
     last_updated: string;
     validation_engine: string;
     description: string;
+    last_auto_update?: string;
+    auto_extracted_data?: {
+      chipsets_count: number;
+      interfaces_count: number;
+      manufacturers_count: number;
+    };
   };
   version_support: {
     current_version: OpenHDVersion;
@@ -220,7 +237,7 @@ export interface HardwareConfiguratorData {
       valid_statuses: ComponentStatus[];
       auto_update_lists: boolean;
     };
-    structured_validation_rules: ValidationRule[];
+    structured_validation_rules: StructuredRule[];
     validation_rules: ValidationRule[]; // Legacy
     performance_matrix: PerformanceEntry[];
   };
@@ -240,6 +257,11 @@ export interface HardwareConfiguratorData {
     format: string;
     description: string;
   }>;
+}
+
+export interface StructuredRule extends ValidationRule {
+  parameters?: RuleParameters;
+  auto_generated?: boolean;
 }
 
 // Evaluation context for rules


### PR DESCRIPTION
## Summary
- add JSX type imports and safer fetch fallbacks for download components to clear TS errors
- replace the GitHub stars context with a typed provider that caches API responses across renders
- align hardware configurator pages, services, and shared types with the new structured rule schema

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d83c3e06cc832fb086a849f3859dd3